### PR TITLE
fixes for julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - osx
   - linux
 julia:
-  - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
-Compat 0.9.4
-DataStructures 0.5.3
+julia 0.7-alpha
+DataStructures 0.9.0

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -2,9 +2,7 @@ __precompile__()
 
 module SortingAlgorithms
 
-using Compat
 using DataStructures
-import Compat.view
 using Base.Sort
 using Base.Order
 
@@ -69,14 +67,14 @@ function sort!(vs::AbstractVector, lo::Int, hi::Int, ::RadixSortAlg, o::Ordering
 
     # Make sure we're sorting a bits type
     T = Base.Order.ordtype(o, vs)
-    if !isbits(T)
+    if !isbitstype(T)
         error("Radix sort only sorts bits types (got $T)")
     end
 
     # Init
     iters = ceil(Integer, sizeof(T)*8/RADIX_SIZE)
     bin = zeros(UInt32, 2^RADIX_SIZE, iters)
-    if lo > 1;  bin[1,:] = lo-1;  end
+    if lo > 1;  bin[1,:] .= lo-1;  end
 
     # Histogram for each element, radix
     for i = lo:hi

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,7 @@
 using SortingAlgorithms
-using Compat, Compat.Test
+using Test
 using StatsBase
-
-if !isdefined(Base, :invpermute!)
-    invpermute! = ipermute!
-end
+using Random
 
 a = rand(1:10000, 1000)
 
@@ -50,7 +47,7 @@ randnans(n) = reinterpret(Float64,[rand(UInt64)|0x7ff8000000000000 for i=1:n])
 
 function randn_with_nans(n,p)
     v = randn(n)
-    x = find(rand(n).<p)
+    x = findall(rand(n).<p)
     v[x] = randnans(length(x))
     return v
 end


### PR DESCRIPTION
Pretty trivial to still support 0.6 here, but given that there has been no functional changes here in 1.5 years I think it is OK to do this anyway. It removes an indirect Compat dependency for all packages that uses SortingAlgorithm. I can add back 0.6 if you prefer.