### PR TITLE
Implements the CombSort algorithm

### DIFF
--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -42,7 +42,6 @@ Characteristics:
 ## References
  - Werneck, N. L., (2020). "ChipSort: a SIMD and cache-aware sorting module. JuliaCon Proceedings, 1(1), 12, https://doi.org/10.21105/jcon.00012
  - H. Inoue, T. Moriyama, H. Komatsu and T. Nakatani, "AA-Sort: A New Parallel Sorting Algorithm for Multi-Core SIMD Processors," 16th International Conference on Parallel Architecture and Compilation Techniques (PACT 2007), 2007, pp. 189-198, doi: 10.1109/PACT.2007.4336211.
- - Vitányi, Paul M. B., (2007). "Analysis of Sorting Algorithms by Kolmogorov Complexity (A Survey)." doi: 10.1007/978-3-540-32777-6
 """
 const CombSort  = CombSortAlg()
 

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -40,6 +40,7 @@ Characteristics:
  - *`n log n` average runtime* measured for random inputs of length up to 100 million, but theoretical runtime of `Θ(n^2)` for extremely long inputs.
 
 ## References
+- Dobosiewicz, Wlodzimierz, (1980). "An efficient variation of bubble sort", Information Processing Letters, 11(1), pp. 5-6, https://doi.org/10.1016/0020-0190(80)90022-8.
  - Werneck, N. L., (2020). "ChipSort: a SIMD and cache-aware sorting module. JuliaCon Proceedings, 1(1), 12, https://doi.org/10.21105/jcon.00012
  - H. Inoue, T. Moriyama, H. Komatsu and T. Nakatani, "AA-Sort: A New Parallel Sorting Algorithm for Multi-Core SIMD Processors," 16th International Conference on Parallel Architecture and Compilation Techniques (PACT 2007), 2007, pp. 189-198, doi: 10.1109/PACT.2007.4336211.
 """

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -601,23 +601,7 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, ::TimSortAlg, o::Ordering)
     return v
 end
 
-# Especial ordering for CombSort
-ltminmax(o::ForwardOrdering,       a, b) = min(a,b), max(a,b)
-ltminmax(o::ReverseOrdering,       a, b) = max(a,b), min(a,b)
-ltminmax(o::By,                    a, b) = ifelse(isless(o.by(a),o.by(b)), a, b), ifelse(isless(o.by(a),o.by(b)), b, a)
-ltminmax(o::Lt,                    a, b) = ifelse(o.lt(a,b), a, b), ifelse(o.lt(a,b), b, a)
-ltminmax(o::Base.Sort.Float.Left,  a, b) = min(a,b), max(a,b)
-ltminmax(o::Base.Sort.Float.Right, a, b) = max(a,b), min(a,b)
-
-Base.@propagate_inbounds function ltminmax(p::Perm, a::Integer, b::Integer)
-    da = p.data[a]
-    db = p.data[b]
-    if lt(p.order, da, db) | !lt(p.order, db, da) & (a < b)
-        (a, b)
-    else
-        (b, a)
-    end
-end
+ltminmax(o::Ordering, a, b) = lt(o, a, b) ? (a, b) : (b, a)
 
 function sort!(v::AbstractVector, lo::Int, hi::Int, ::CombSortAlg, o::Ordering)
     interval = (3 * (hi-lo+1)) >> 2

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -22,18 +22,22 @@ const RadixSort = RadixSortAlg()
 
 """
     CombSort
+
 Indicates that a sorting function should use the comb sort
 algorithm. Comb sort traverses the collection multiple times
 ordering pairs of elements with a given interval between them.
 The interval decreases exponentially until it becomes 1, then
 it switches to insertion sort on the whole input.
 Characteristics:
-  * *not stable*: does not preserve the ordering of elements which
-    compare equal (e.g. "a" and "A" in a sort of letters which
-    ignores case).
-  * *in-place* in memory.
-  * *parallelizable* this algorithm is suitable for vectorization
-    because it performs many independent comparisons.
+ - *not stable*: does not preserve the ordering of elements which
+   compare equal (e.g. "a" and "A" in a sort of letters which
+   ignores case).
+ - *in-place* in memory.
+ - *parallelizable* this algorithm is suitable for vectorization
+   because it performs many independent comparisons.
+
+## References
+ - H. Inoue, T. Moriyama, H. Komatsu and T. Nakatani, "AA-Sort: A New Parallel Sorting Algorithm for Multi-Core SIMD Processors," 16th International Conference on Parallel Architecture and Compilation Techniques (PACT 2007), 2007, pp. 189-198, doi: 10.1109/PACT.2007.4336211.
 """
 const CombSort  = CombSortAlg()
 

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -608,7 +608,7 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, ::CombSortAlg, o::Ordering)
     while interval > 1
         @inbounds for j in lo:hi-interval
             a, b = v[j], v[j+interval]
-            v[j], v[j+interval] = lt(o, a, b) ? (a, b) : (b, a)
+            v[j], v[j+interval] = lt(o, b, a) ? (b, a) : (a, b)
         end
         interval = (3 * interval) >> 2
     end

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -28,12 +28,13 @@ algorithm. Comb sort traverses the collection multiple times
 ordering pairs of elements with a given interval between them.
 The interval decreases exponentially until it becomes 1, then
 it switches to insertion sort on the whole input.
+
 Characteristics:
  - *not stable*: does not preserve the ordering of elements which
    compare equal (e.g. "a" and "A" in a sort of letters which
    ignores case).
  - *in-place* in memory.
- - *parallelizable* this algorithm is suitable for vectorization
+ - *parallelizable* suitable for vectorization with SIMD instructions
    because it performs many independent comparisons.
 
 ## References

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -602,14 +602,13 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, ::TimSortAlg, o::Ordering)
     return v
 end
 
-ltminmax(o::Ordering, a, b) = lt(o, a, b) ? (a, b) : (b, a)
-
 function sort!(v::AbstractVector, lo::Int, hi::Int, ::CombSortAlg, o::Ordering)
     interval = (3 * (hi-lo+1)) >> 2
 
     @inbounds while interval > 1
         for j in lo:hi-interval
-            v[j], v[j+interval] = ltminmax(o, v[j], v[j+interval])
+            a, b = v[j], v[j+interval]
+            v[j], v[j+interval] = lt(o, a, b) ? (a, b) : (b, a)
         end
         interval = (3 * interval) >> 2
     end

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -30,16 +30,18 @@ The interval decreases exponentially until it becomes 1, then
 it switches to insertion sort on the whole input.
 
 Characteristics:
- - *not stable*: does not preserve the ordering of elements which
+ - *not stable* does not preserve the ordering of elements which
    compare equal (e.g. "a" and "A" in a sort of letters which
    ignores case).
  - *in-place* in memory.
  - *parallelizable* suitable for vectorization with SIMD instructions
    because it performs many independent comparisons.
+ - *complexity* worst-case only proven to be better than quadratic, but not `n*log(n)`.
 
 ## References
+ - Werneck, N. L., (2020). "ChipSort: a SIMD and cache-aware sorting module. JuliaCon Proceedings, 1(1), 12, https://doi.org/10.21105/jcon.00012
  - H. Inoue, T. Moriyama, H. Komatsu and T. Nakatani, "AA-Sort: A New Parallel Sorting Algorithm for Multi-Core SIMD Processors," 16th International Conference on Parallel Architecture and Compilation Techniques (PACT 2007), 2007, pp. 189-198, doi: 10.1109/PACT.2007.4336211.
- - Werneck, N. L., (2020). ChipSort: a SIMD and cache-aware sorting module. JuliaCon Proceedings, 1(1), 12, https://doi.org/10.21105/jcon.00012
+ - Vitányi, Paul M. B., (2007). "Analysis of Sorting Algorithms by Kolmogorov Complexity (A Survey)." doi: 10.1007/978-3-540-32777-6
 """
 const CombSort  = CombSortAlg()
 

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -36,7 +36,8 @@ Characteristics:
  - *in-place* in memory.
  - *parallelizable* suitable for vectorization with SIMD instructions
    because it performs many independent comparisons.
- - *complexity* worst-case only proven to be better than quadratic, but not `n*log(n)`.
+ - *pathological inputs* such as `repeat(1:5.0, 4^8)` can make this algorithm perform very poorly.
+ - *`n log n` average runtime* measured for random inputs of length up to 100 million, but theoretical runtime of `Θ(n^2)` for extremely long inputs.
 
 ## References
  - Werneck, N. L., (2020). "ChipSort: a SIMD and cache-aware sorting module. JuliaCon Proceedings, 1(1), 12, https://doi.org/10.21105/jcon.00012

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -606,7 +606,7 @@ ltminmax(o::Base.Sort.Float.Right, a, b) = max(a,b), min(a,b)
 Base.@propagate_inbounds function ltminmax(p::Perm, a::Integer, b::Integer)
     da = p.data[a]
     db = p.data[b]
-    if (lt(p.order, da, db) | (!lt(p.order, db, da) & (a < b)))
+    if lt(p.order, da, db) | !lt(p.order, db, da) & (a < b)
         (a, b)
     else
         (b, a)

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -605,8 +605,8 @@ end
 function sort!(v::AbstractVector, lo::Int, hi::Int, ::CombSortAlg, o::Ordering)
     interval = (3 * (hi-lo+1)) >> 2
 
-    @inbounds while interval > 1
-        for j in lo:hi-interval
+    while interval > 1
+        @inbounds for j in lo:hi-interval
             a, b = v[j], v[j+interval]
             v[j], v[j+interval] = lt(o, a, b) ? (a, b) : (b, a)
         end

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -39,6 +39,7 @@ Characteristics:
 
 ## References
  - H. Inoue, T. Moriyama, H. Komatsu and T. Nakatani, "AA-Sort: A New Parallel Sorting Algorithm for Multi-Core SIMD Processors," 16th International Conference on Parallel Architecture and Compilation Techniques (PACT 2007), 2007, pp. 189-198, doi: 10.1109/PACT.2007.4336211.
+ - Werneck, N. L., (2020). ChipSort: a SIMD and cache-aware sorting module. JuliaCon Proceedings, 1(1), 12, https://doi.org/10.21105/jcon.00012
 """
 const CombSort  = CombSortAlg()
 

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -19,6 +19,7 @@ struct CombSortAlg  <: Algorithm end
 const HeapSort  = HeapSortAlg()
 const TimSort   = TimSortAlg()
 const RadixSort = RadixSortAlg()
+
 """
     CombSort
 Indicates that a sorting function should use the comb sort

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -618,7 +618,6 @@ Base.@propagate_inbounds function ltminmax(p::Perm, a::Integer, b::Integer)
     end
 end
 
-# CombSort
 function sort!(v::AbstractVector, lo::Int, hi::Int, ::CombSortAlg, o::Ordering)
     interval = (3 * (hi-lo+1)) >> 2
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Random
 
 a = rand(1:10000, 1000)
 
-for alg in [TimSort, HeapSort, RadixSort]
+for alg in [TimSort, HeapSort, RadixSort, CombSort]
     b = sort(a, alg=alg)
     @test issorted(b)
     ix = sortperm(a, alg=alg)
@@ -85,7 +85,7 @@ for n in [0:10..., 100, 101, 1000, 1001]
         end
 
         # unstable algorithms
-        for alg in [HeapSort]
+        for alg in [HeapSort, CombSort]
             p = sortperm(v, alg=alg, order=ord)
             @test isperm(p)
             @test v[p] == si
@@ -99,7 +99,7 @@ for n in [0:10..., 100, 101, 1000, 1001]
 
     v = randn_with_nans(n,0.1)
     for ord in [Base.Order.Forward, Base.Order.Reverse],
-        alg in [TimSort, HeapSort, RadixSort]
+        alg in [TimSort, HeapSort, RadixSort, CombSort]
         # test float sorting with NaNs
         s = sort(v, alg=alg, order=ord)
         @test issorted(s, order=ord)


### PR DESCRIPTION
This implements the comb sort algorithm. The patch was first submitted to Julia core, but it was decided that SortingAlgorithms.jl would be a better place. https://github.com/JuliaLang/julia/pull/32696

Please check previous threads for details and motivation. This algorithm was discussed in a 2019 JuliaCon presentation  https://youtu.be/_bvb8X4DT90?t=402 . The main motivation to use comb sort is that the algorithm happens to lead itself very well to compiler optimizations, especially vectorization. This can be checked by running e.g. ` @code_llvm sort!(rand(Int32, 2^12), 1, 2^12, CombSort, Base.Order.Forward)` and looking for an instruction such as `icmp slt <8 x i32>`.

Comb sort is a general, non-stable comparison sort that outperforms the standard quick/intro sort for 32-bit integers. It doesn't seem to outperform radix sort for that kind of element type, though. So it's not clear whether it only outperforms quick sort in the cases where radix sort is actually optimal. The motivation is that comb sort is a simple general-purpose algorithm that seems to be easily optimized by the compiler to exploit modern parallel architectures.

I'd gladly perform more benchmarks if this is desired, although it would be nice to hear specific ideas of the kind of input types and sizes we are interested in. As far as I know, none of the currently implemented algorithms had to be validated with such experiments before being merged. It would be great to hear some advice about moving forward with this contribution, if at all, since this peculiar algorithm seems to attract a high level of scrutiny, probably deserved.

All the tests right now seem to be heavily based on floating-point numbers, and here there's actually some challenges in the implementation. The core of the implementation is the function `ltminmax` which compares two values and returns an ordered pair using the `min` and `max` functions. This is perfect for integers and strings, but with floating-point things get weird, as usual. The results with NaNs right now are actually not even correct, although the test is passing (!). It would be great to have some advice about how to fix that, as well as how we might extend the tests.

I'm very glad to have studied this algorithm using Julia, I feel it's a great showcase for the language, and it seems to epitomize modern, parallel-focused computing. I'd love to hear suggestions about how we might highlight these ideas in this patch.