### PR TITLE
Tag 1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SortingAlgorithms"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Notable changes include:
- Add comb sort, forces minor version bump (#54)
- Use Base's radix sort for Julia 1.9+ (#63)