### PR TITLE
Add comment to broken test and fix it by using Base.Sort.InitialOptimizations

### DIFF
--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -16,9 +16,12 @@ struct TimSortAlg   <: Algorithm end
 struct RadixSortAlg <: Algorithm end
 struct CombSortAlg  <: Algorithm end
 
-const HeapSort  = HeapSortAlg()
-const TimSort   = TimSortAlg()
-const RadixSort = RadixSortAlg()
+function maybe_optimize(x::Algorithm) 
+    isdefined(Base.Sort, InitialOptimizations) ? Base.Sort.InitialOptimizations(x) : x
+end     
+const HeapSort  = maybe_optimize(HeapSortAlg())
+const TimSort   = maybe_optimize(TimSortAlg())
+const RadixSort = maybe_optimize(RadixSortAlg())
 
 """
     CombSort

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -21,7 +21,9 @@ function maybe_optimize(x::Algorithm)
 end     
 const HeapSort  = maybe_optimize(HeapSortAlg())
 const TimSort   = maybe_optimize(TimSortAlg())
-const RadixSort = maybe_optimize(RadixSortAlg())
+# Whenever InitialOptimizations is defined, RadixSort falls 
+# back to Base.DEFAULT_STABLE which already incldues them.
+const RadixSort = RadixSortAlg()
 
 """
     CombSort

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -47,7 +47,7 @@ Characteristics:
  - Werneck, N. L., (2020). "ChipSort: a SIMD and cache-aware sorting module. JuliaCon Proceedings, 1(1), 12, https://doi.org/10.21105/jcon.00012
  - H. Inoue, T. Moriyama, H. Komatsu and T. Nakatani, "AA-Sort: A New Parallel Sorting Algorithm for Multi-Core SIMD Processors," 16th International Conference on Parallel Architecture and Compilation Techniques (PACT 2007), 2007, pp. 189-198, doi: 10.1109/PACT.2007.4336211.
 """
-const CombSort  = CombSortAlg()
+const CombSort  = maybe_optimize(CombSortAlg())
 
 
 ## Heap sort

--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -17,7 +17,7 @@ struct RadixSortAlg <: Algorithm end
 struct CombSortAlg  <: Algorithm end
 
 function maybe_optimize(x::Algorithm) 
-    isdefined(Base.Sort, InitialOptimizations) ? Base.Sort.InitialOptimizations(x) : x
+    isdefined(Base.Sort, :InitialOptimizations) ? Base.Sort.InitialOptimizations(x) : x
 end     
 const HeapSort  = maybe_optimize(HeapSortAlg())
 const TimSort   = maybe_optimize(TimSortAlg())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,13 +103,13 @@ for n in [0:10..., 100, 101, 1000, 1001]
         # test float sorting with NaNs
         s = sort(v, alg=alg, order=ord)
         @test issorted(s, order=ord)
-        @test reinterpret(UInt64, v[map(isnan, v)]) == reinterpret(UInt64, s[map(isnan, s)])
+        @test reinterpret(UInt64, v[map(isnan, v)]) == reinterpret(UInt64, s[map(isnan, s)]) #?
 
         # test float permutation with NaNs
         p = sortperm(v, alg=alg, order=ord)
         @test isperm(p)
         vp = v[p]
         @test isequal(vp,s)
-        @test reinterpret(UInt64,vp) == reinterpret(UInt64,s)
+        @test reinterpret(UInt64,vp) == reinterpret(UInt64,s) #?
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,13 +103,17 @@ for n in [0:10..., 100, 101, 1000, 1001]
         # test float sorting with NaNs
         s = sort(v, alg=alg, order=ord)
         @test issorted(s, order=ord)
-        @test reinterpret(UInt64, v[map(isnan, v)]) == reinterpret(UInt64, s[map(isnan, s)]) #?
+        
+        # This tests that NaNs (which compare equivalent) are treated stably 
+        # even when the underlying algorithm is unstable. That it happens to
+        # pass is not a part of the public API:
+        @test reinterpret(UInt64, v[map(isnan, v)]) == reinterpret(UInt64, s[map(isnan, s)])
 
         # test float permutation with NaNs
         p = sortperm(v, alg=alg, order=ord)
         @test isperm(p)
         vp = v[p]
         @test isequal(vp,s)
-        @test reinterpret(UInt64,vp) == reinterpret(UInt64,s) #?
+        @test reinterpret(UInt64,vp) == reinterpret(UInt64,s)
     end
 end


### PR DESCRIPTION
The functional change in this PR is to opt into Base.Sort.InitialOptimizations for exported sorting algorithms. This should typically be a performance improvement. 

The test commented upon here is questionable because it tests for stable results when sorting with unstable algorithms. Nevertheless, it passed in 1.8 and will continue to pass in 1.9 because we utilize Base.Sort.IEEEFloatOptimization to handle the NaN case for us in a stable manner.

Before this PR, that test failed on nightly (see failure of f8571723212c831f1e77f785353fef3ada443267, for example).