### PR TITLE
Allow version 0.19 of DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "1.2.1"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 
 [compat]
-DataStructures = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
+DataStructures = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Might be good to set up CompatHelper to simplify this although there is only a single dependency.

Might also be better to test on `pre` instead of `nightly`.