### PR TITLE
Partially revert "Adjust CI Julia versions"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,9 @@ jobs:
       matrix:
         version:
           - '1.0'
+          - 'lts'
           - '1'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,17 +6,6 @@ on:
       - main
     tags: '*'
 jobs:
-  finalize:
-    timeout-minutes: 10
-    needs: [test]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo test: ${{ needs.test.result }}
-      - run: exit 1
-        if: |
-          (needs.test.result != 'success')
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
@@ -24,10 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'min'
-          - 'lts'
+          - '1.0'
           - '1'
-          - 'pre'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Partially reverts JuliaCollections/SortingAlgorithms.jl#102.

Notably, I prefer `1.0` over `min` because that is one extra step in the way of accidentally dropping 1.0 compat.

I'm happy to test `lts` and `pre` in addition to the existing matrix. For a high-dependent, low-chrun package, extensive CI is appropriate.