### PR TITLE
Allow version 0.19 of DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ julia = "1"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Random", "Test"]
+test = ["Aqua", "Random", "StatsBase", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,7 @@ julia = "1"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Random", "StatsBase", "Test"]
+test = ["Aqua", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "1.2.1"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 
 [compat]
-DataStructures = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
+DataStructures = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
 julia = "1"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SortingAlgorithms
 using Test
-# using StatsBase
+using StatsBase
 using Random
 
 stable_algorithms = [TimSort, RadixSort, PagedMergeSort]
@@ -81,14 +81,14 @@ Random.seed!(0xdeadbeef)
 for n in [0:10..., 100, 101, 1000, 1001]
     r = 1:10
     v = rand(1:10,n)
-    # h = fit(Histogram, v, r)
+    h = fit(Histogram, v, r)
 
     for ord in [Base.Order.Forward, Base.Order.Reverse]
         # insertion sort (stable) as reference
         pi = sortperm(v, alg=InsertionSort, order=ord)
         @test isperm(pi)
         si = v[pi]
-        # @test fit(Histogram, si, r) == h
+        @test fit(Histogram, si, r) == h
         @test issorted(si, order=ord)
         @test all(issorted,[pi[si.==x] for x in r])
         c = copy(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SortingAlgorithms
 using Test
-using StatsBase
+# using StatsBase
 using Random
 
 stable_algorithms = [TimSort, RadixSort, PagedMergeSort]
@@ -81,14 +81,14 @@ Random.seed!(0xdeadbeef)
 for n in [0:10..., 100, 101, 1000, 1001]
     r = 1:10
     v = rand(1:10,n)
-    h = fit(Histogram, v, r)
+    # h = fit(Histogram, v, r)
 
     for ord in [Base.Order.Forward, Base.Order.Reverse]
         # insertion sort (stable) as reference
         pi = sortperm(v, alg=InsertionSort, order=ord)
         @test isperm(pi)
         si = v[pi]
-        @test fit(Histogram, si, r) == h
+        # @test fit(Histogram, si, r) == h
         @test issorted(si, order=ord)
         @test all(issorted,[pi[si.==x] for x in r])
         c = copy(v)


### PR DESCRIPTION
- **Allow version 0.19 of DataStructures**
- **Drop mostly-unnecessary test dep on StatsBase** To be reverted. A simple hack to actually run tests.
- **Revert "Drop mostly-unnecessary test dep on StatsBase"**