### PR TITLE
Release 1.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SortingAlgorithms"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Declares compatibility with DataStructures 0.19

@andreasnoack or @DilumAluthge feel free to merge this and trigger JuliaRegistrator if the changes and testing look adequate to you. Or feel free to suggest additional changes to include prior to release. If I don't hear back I'll merge and release around EOD tomorrow.

Thanks for helping keep this package form holding users back from the latest release of DataStructures!