### PR TITLE
Remove circular test dependency on StatsBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,7 @@ julia = "1"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Random", "StatsBase", "Test"]
+test = ["Aqua", "Random", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using SortingAlgorithms
 using Test
-using StatsBase
 using Random
 
 stable_algorithms = [TimSort, RadixSort, PagedMergeSort]
@@ -81,14 +80,12 @@ Random.seed!(0xdeadbeef)
 for n in [0:10..., 100, 101, 1000, 1001]
     r = 1:10
     v = rand(1:10,n)
-    h = fit(Histogram, v, r)
 
     for ord in [Base.Order.Forward, Base.Order.Reverse]
         # insertion sort (stable) as reference
         pi = sortperm(v, alg=InsertionSort, order=ord)
         @test isperm(pi)
         si = v[pi]
-        @test fit(Histogram, si, r) == h
         @test issorted(si, order=ord)
         @test all(issorted,[pi[si.==x] for x in r])
         c = copy(v)


### PR DESCRIPTION
The PR removes the circular test dependency on StatsBase. IMO circular dependencies are problematic, even if they are limited to tests, since they make the release process more challenging (see https://github.com/JuliaCollections/SortingAlgorithms.jl/pull/101).

At first glance, the usefulness of the StatsBase-related test seems dubious as well. If these tests are deemed useful, I think the better approach would be to run downstream tests with the latest release of StatsBase in CI.