### PR TITLE
Fully qualify Base.Sort.SMALL_ALGORITHM

### DIFF
--- a/src/SortingAlgorithms.jl
+++ b/src/SortingAlgorithms.jl
@@ -908,7 +908,7 @@ midpoint(lo::Integer, hi::Integer) = lo + ((hi - lo) >>> 0x01)
 
 function pagedmergesort!(v::AbstractVector{T}, lo::Integer, hi::Integer, o::Ordering, scratch::AbstractVector{T}, pageLocations) where {T}
     len = hi + 1 - lo
-    if len <= Base.SMALL_THRESHOLD
+    if len <= Base.Sort.SMALL_THRESHOLD
         return Base.Sort.sort!(v, lo, hi, Base.Sort.InsertionSortAlg(), o)
     end
     m = midpoint(lo, hi - 1) # hi-1: ensure midpoint is rounded down. OK, because lo < hi is satisfied here


### PR DESCRIPTION
This is the public way to access it. SMALL_ALGORITHM is public in Sort and Sort is public in Base, but SMALL_ALGORITHM is not public in Base.

This also survives https://github.com/JuliaLang/julia/pull/62133.